### PR TITLE
chore: Adds settings and extension recommendations to vscode

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "huff-language.huff-language",
+        "JuanBlanco.solidity"
+    ],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "git.detectSubmodules": false
+}


### PR DESCRIPTION
Git submodules makes source tracking in vscode annoying with multiple windows open. Having the right extension for huff is necessary to code effectively.